### PR TITLE
Add modified files for RPi Codec Zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 Tools for the IQaudIO Pi-Codec+ / Pi-CodecZero sound card
 
+The `RPi_*.state` files are for the Raspberry Pi-branded Codec Zero board (green PCB). 
+
 To load a state file, from the command line use:
 
+```
 sudo alsactl restore -f filename.state
-
+```

--- a/RPi_Zero_AUXIN_record_and_HP_playback.state
+++ b/RPi_Zero_AUXIN_record_and_HP_playback.state
@@ -1,0 +1,1194 @@
+state.Zero {
+	control.1 {
+		iface MIXER
+		name 'Mic 1 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -600
+			dbmax 3600
+			dbvalue.0 -600
+		}
+	}
+	control.2 {
+		iface MIXER
+		name 'Mic 2 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -600
+			dbmax 3600
+			dbvalue.0 -600
+		}
+	}
+	control.3 {
+		iface MIXER
+		name 'Aux Volume'
+		value.0 53
+		value.1 53
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 63'
+			dbmin -5400
+			dbmax 1500
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.4 {
+		iface MIXER
+		name 'Mixin PGA Volume'
+		value.0 7
+		value.1 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 15'
+			dbmin -450
+			dbmax 1800
+			dbvalue.0 600
+			dbvalue.1 600
+		}
+	}
+	control.5 {
+		iface MIXER
+		name 'ADC Volume'
+		value.0 112
+		value.1 112
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 127'
+			dbmin -9999999
+			dbmax 1125
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.6 {
+		iface MIXER
+		name 'DAC Volume'
+		value.0 112
+		value.1 112
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 127'
+			dbmin -9999999
+			dbmax 1125
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.7 {
+		iface MIXER
+		name 'Headphone Volume'
+		value.0 49
+		value.1 49
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 63'
+			dbmin -5700
+			dbmax 600
+			dbvalue.0 -800
+			dbvalue.1 -800
+		}
+	}
+	control.8 {
+		iface MIXER
+		name 'Lineout Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+			dbmin -4800
+			dbmax 1500
+			dbvalue.0 -4800
+		}
+	}
+	control.9 {
+		iface MIXER
+		name 'DAC EQ Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.10 {
+		iface MIXER
+		name 'DAC EQ1 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.11 {
+		iface MIXER
+		name 'DAC EQ2 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.12 {
+		iface MIXER
+		name 'DAC EQ3 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.13 {
+		iface MIXER
+		name 'DAC EQ4 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.14 {
+		iface MIXER
+		name 'DAC EQ5 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.15 {
+		iface MIXER
+		name 'ADC HPF Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.16 {
+		iface MIXER
+		name 'ADC HPF Cutoff'
+		value Fs/24000
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Fs/24000
+			item.1 Fs/12000
+			item.2 Fs/6000
+			item.3 Fs/3000
+		}
+	}
+	control.17 {
+		iface MIXER
+		name 'ADC Voice Mode Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.18 {
+		iface MIXER
+		name 'ADC Voice Cutoff'
+		value '2.5Hz'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '2.5Hz'
+			item.1 '25Hz'
+			item.2 '50Hz'
+			item.3 '100Hz'
+			item.4 '150Hz'
+			item.5 '200Hz'
+			item.6 '300Hz'
+			item.7 '400Hz'
+		}
+	}
+	control.19 {
+		iface MIXER
+		name 'DAC HPF Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.20 {
+		iface MIXER
+		name 'DAC HPF Cutoff'
+		value Fs/24000
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Fs/24000
+			item.1 Fs/12000
+			item.2 Fs/6000
+			item.3 Fs/3000
+		}
+	}
+	control.21 {
+		iface MIXER
+		name 'DAC Voice Mode Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.22 {
+		iface MIXER
+		name 'DAC Voice Cutoff'
+		value '2.5Hz'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '2.5Hz'
+			item.1 '25Hz'
+			item.2 '50Hz'
+			item.3 '100Hz'
+			item.4 '150Hz'
+			item.5 '200Hz'
+			item.6 '300Hz'
+			item.7 '400Hz'
+		}
+	}
+	control.23 {
+		iface MIXER
+		name 'Mic 1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.24 {
+		iface MIXER
+		name 'Mic 2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.25 {
+		iface MIXER
+		name 'Aux Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.26 {
+		iface MIXER
+		name 'Mixin PGA Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.27 {
+		iface MIXER
+		name 'ADC Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.28 {
+		iface MIXER
+		name 'Headphone Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.29 {
+		iface MIXER
+		name 'Lineout Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.30 {
+		iface MIXER
+		name 'DAC Soft Mute Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.31 {
+		iface MIXER
+		name 'DAC Soft Mute Rate'
+		value '1'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '1'
+			item.1 '2'
+			item.2 '4'
+			item.3 '8'
+			item.4 '16'
+			item.5 '32'
+			item.6 '64'
+		}
+	}
+	control.32 {
+		iface MIXER
+		name 'Aux ZC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.33 {
+		iface MIXER
+		name 'Mixin PGA ZC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.34 {
+		iface MIXER
+		name 'Headphone ZC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.35 {
+		iface MIXER
+		name 'Aux Gain Ramping Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.36 {
+		iface MIXER
+		name 'Mixin Gain Ramping Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.37 {
+		iface MIXER
+		name 'ADC Gain Ramping Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.38 {
+		iface MIXER
+		name 'DAC Gain Ramping Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.39 {
+		iface MIXER
+		name 'Headphone Gain Ramping Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.40 {
+		iface MIXER
+		name 'Lineout Gain Ramping Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.41 {
+		iface MIXER
+		name 'Gain Ramping Rate'
+		value 'nominal rate * 8'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'nominal rate * 8'
+			item.1 'nominal rate * 16'
+			item.2 'nominal rate / 16'
+			item.3 'nominal rate / 32'
+		}
+	}
+	control.42 {
+		iface MIXER
+		name 'DAC NG Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.43 {
+		iface MIXER
+		name 'DAC NG Setup Time'
+		value '256 samples'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '256 samples'
+			item.1 '512 samples'
+			item.2 '1024 samples'
+			item.3 '2048 samples'
+		}
+	}
+	control.44 {
+		iface MIXER
+		name 'DAC NG Rampup Rate'
+		value '0.02 ms/dB'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '0.02 ms/dB'
+			item.1 '0.16 ms/dB'
+		}
+	}
+	control.45 {
+		iface MIXER
+		name 'DAC NG Rampdown Rate'
+		value '0.64 ms/dB'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '0.64 ms/dB'
+			item.1 '20.48 ms/dB'
+		}
+	}
+	control.46 {
+		iface MIXER
+		name 'DAC NG OFF Threshold'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.47 {
+		iface MIXER
+		name 'DAC NG ON Threshold'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.48 {
+		iface MIXER
+		name 'DAC Mono Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.49 {
+		iface MIXER
+		name 'DAC Invert Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.50 {
+		iface MIXER
+		name 'DMIC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.51 {
+		iface MIXER
+		name 'ALC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.52 {
+		iface MIXER
+		name 'ALC Attack Rate'
+		value '44/fs'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '44/fs'
+			item.1 '88/fs'
+			item.2 '176/fs'
+			item.3 '352/fs'
+			item.4 '704/fs'
+			item.5 '1408/fs'
+			item.6 '2816/fs'
+			item.7 '5632/fs'
+			item.8 '11264/fs'
+			item.9 '22528/fs'
+			item.10 '45056/fs'
+			item.11 '90112/fs'
+			item.12 '180224/fs'
+		}
+	}
+	control.53 {
+		iface MIXER
+		name 'ALC Release Rate'
+		value '176/fs'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '176/fs'
+			item.1 '352/fs'
+			item.2 '704/fs'
+			item.3 '1408/fs'
+			item.4 '2816/fs'
+			item.5 '5632/fs'
+			item.6 '11264/fs'
+			item.7 '22528/fs'
+			item.8 '45056/fs'
+			item.9 '90112/fs'
+			item.10 '180224/fs'
+		}
+	}
+	control.54 {
+		iface MIXER
+		name 'ALC Hold Time'
+		value '62/fs'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '62/fs'
+			item.1 '124/fs'
+			item.2 '248/fs'
+			item.3 '496/fs'
+			item.4 '992/fs'
+			item.5 '1984/fs'
+			item.6 '3968/fs'
+			item.7 '7936/fs'
+			item.8 '15872/fs'
+			item.9 '31744/fs'
+			item.10 '63488/fs'
+			item.11 '126976/fs'
+			item.12 '253952/fs'
+			item.13 '507904/fs'
+			item.14 '1015808/fs'
+			item.15 '2031616/fs'
+		}
+	}
+	control.55 {
+		iface MIXER
+		name 'ALC Integ Attack Rate'
+		value '1/4'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '1/4'
+			item.1 '1/16'
+			item.2 '1/256'
+			item.3 '1/65536'
+		}
+	}
+	control.56 {
+		iface MIXER
+		name 'ALC Integ Release Rate'
+		value '1/4'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '1/4'
+			item.1 '1/16'
+			item.2 '1/256'
+			item.3 '1/65536'
+		}
+	}
+	control.57 {
+		iface MIXER
+		name 'ALC Noise Threshold Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+			dbmin -9450
+			dbmax 0
+			dbvalue.0 -9450
+		}
+	}
+	control.58 {
+		iface MIXER
+		name 'ALC Min Threshold Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+			dbmin -9450
+			dbmax 0
+			dbvalue.0 -9450
+		}
+	}
+	control.59 {
+		iface MIXER
+		name 'ALC Max Threshold Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+			dbmin -9450
+			dbmax 0
+			dbvalue.0 -9450
+		}
+	}
+	control.60 {
+		iface MIXER
+		name 'ALC Max Attenuation Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin 0
+			dbmax 9000
+			dbvalue.0 0
+		}
+	}
+	control.61 {
+		iface MIXER
+		name 'ALC Max Gain Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin 0
+			dbmax 9000
+			dbvalue.0 0
+		}
+	}
+	control.62 {
+		iface MIXER
+		name 'ALC Min Analog Gain Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -9999999
+			dbmax 3600
+			dbvalue.0 -9999999
+		}
+	}
+	control.63 {
+		iface MIXER
+		name 'ALC Max Analog Gain Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -9999999
+			dbmax 3600
+			dbvalue.0 -9999999
+		}
+	}
+	control.64 {
+		iface MIXER
+		name 'ALC Anticlip Mode Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.65 {
+		iface MIXER
+		name 'ALC Anticlip Level'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 127'
+		}
+	}
+	control.66 {
+		iface MIXER
+		name 'HP Jack Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.67 {
+		iface MIXER
+		name 'MIC Jack Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.68 {
+		iface MIXER
+		name 'Onboard MIC Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.69 {
+		iface MIXER
+		name 'AUX Jack Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.70 {
+		iface MIXER
+		name 'Mic 1 Amp Source MUX'
+		value Differential
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Differential
+			item.1 MIC_P
+			item.2 MIC_N
+		}
+	}
+	control.71 {
+		iface MIXER
+		name 'Mic 2 Amp Source MUX'
+		value Differential
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Differential
+			item.1 MIC_P
+			item.2 MIC_N
+		}
+	}
+	control.72 {
+		iface MIXER
+		name 'Mixin Left Aux Left Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.73 {
+		iface MIXER
+		name 'Mixin Left Mic 1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.74 {
+		iface MIXER
+		name 'Mixin Left Mic 2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.75 {
+		iface MIXER
+		name 'Mixin Left Mixin Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.76 {
+		iface MIXER
+		name 'Mixin Right Aux Right Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.77 {
+		iface MIXER
+		name 'Mixin Right Mic 2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.78 {
+		iface MIXER
+		name 'Mixin Right Mic 1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.79 {
+		iface MIXER
+		name 'Mixin Right Mixin Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.80 {
+		iface MIXER
+		name 'DAI Left Source MUX'
+		value 'ADC Left'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'ADC Left'
+			item.1 'ADC Right'
+			item.2 'DAI Input Left'
+			item.3 'DAI Input Right'
+		}
+	}
+	control.81 {
+		iface MIXER
+		name 'DAI Right Source MUX'
+		value 'ADC Right'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'ADC Left'
+			item.1 'ADC Right'
+			item.2 'DAI Input Left'
+			item.3 'DAI Input Right'
+		}
+	}
+	control.82 {
+		iface MIXER
+		name 'DAC Left Source MUX'
+		value 'DAI Input Left'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'ADC Output Left'
+			item.1 'ADC Output Right'
+			item.2 'DAI Input Left'
+			item.3 'DAI Input Right'
+		}
+	}
+	control.83 {
+		iface MIXER
+		name 'DAC Right Source MUX'
+		value 'DAI Input Right'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'ADC Output Left'
+			item.1 'ADC Output Right'
+			item.2 'DAI Input Left'
+			item.3 'DAI Input Right'
+		}
+	}
+	control.84 {
+		iface MIXER
+		name 'Mixout Left Aux Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.85 {
+		iface MIXER
+		name 'Mixout Left Mixin Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.86 {
+		iface MIXER
+		name 'Mixout Left Mixin Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.87 {
+		iface MIXER
+		name 'Mixout Left DAC Left Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.88 {
+		iface MIXER
+		name 'Mixout Left Aux Left Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.89 {
+		iface MIXER
+		name 'Mixout Left Mixin Left Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.90 {
+		iface MIXER
+		name 'Mixout Left Mixin Right Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.91 {
+		iface MIXER
+		name 'Mixout Right Aux Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.92 {
+		iface MIXER
+		name 'Mixout Right Mixin Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.93 {
+		iface MIXER
+		name 'Mixout Right Mixin Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.94 {
+		iface MIXER
+		name 'Mixout Right DAC Right Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.95 {
+		iface MIXER
+		name 'Mixout Right Aux Right Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.96 {
+		iface MIXER
+		name 'Mixout Right Mixin Right Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.97 {
+		iface MIXER
+		name 'Mixout Right Mixin Left Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+}

--- a/RPi_Zero_OnboardMIC_record_and_SPK_playback.state
+++ b/RPi_Zero_OnboardMIC_record_and_SPK_playback.state
@@ -1,0 +1,1194 @@
+state.Zero {
+	control.1 {
+		iface MIXER
+		name 'Mic 1 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -600
+			dbmax 3600
+			dbvalue.0 -600
+		}
+	}
+	control.2 {
+		iface MIXER
+		name 'Mic 2 Volume'
+		value 5
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -600
+			dbmax 3600
+			dbvalue.0 2400
+		}
+	}
+	control.3 {
+		iface MIXER
+		name 'Aux Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 63'
+			dbmin -5400
+			dbmax 1500
+			dbvalue.0 -5400
+			dbvalue.1 -5400
+		}
+	}
+	control.4 {
+		iface MIXER
+		name 'Mixin PGA Volume'
+		value.0 7
+		value.1 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 15'
+			dbmin -450
+			dbmax 1800
+			dbvalue.0 600
+			dbvalue.1 600
+		}
+	}
+	control.5 {
+		iface MIXER
+		name 'ADC Volume'
+		value.0 114
+		value.1 114
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 127'
+			dbmin -9999999
+			dbmax 1125
+			dbvalue.0 150
+			dbvalue.1 150
+		}
+	}
+	control.6 {
+		iface MIXER
+		name 'DAC Volume'
+		value.0 112
+		value.1 112
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 127'
+			dbmin -9999999
+			dbmax 1125
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.7 {
+		iface MIXER
+		name 'Headphone Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 63'
+			dbmin -5700
+			dbmax 600
+			dbvalue.0 -5700
+			dbvalue.1 -5700
+		}
+	}
+	control.8 {
+		iface MIXER
+		name 'Lineout Volume'
+		value 48
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+			dbmin -4800
+			dbmax 1500
+			dbvalue.0 0
+		}
+	}
+	control.9 {
+		iface MIXER
+		name 'DAC EQ Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.10 {
+		iface MIXER
+		name 'DAC EQ1 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.11 {
+		iface MIXER
+		name 'DAC EQ2 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.12 {
+		iface MIXER
+		name 'DAC EQ3 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.13 {
+		iface MIXER
+		name 'DAC EQ4 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.14 {
+		iface MIXER
+		name 'DAC EQ5 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.15 {
+		iface MIXER
+		name 'ADC HPF Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.16 {
+		iface MIXER
+		name 'ADC HPF Cutoff'
+		value Fs/24000
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Fs/24000
+			item.1 Fs/12000
+			item.2 Fs/6000
+			item.3 Fs/3000
+		}
+	}
+	control.17 {
+		iface MIXER
+		name 'ADC Voice Mode Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.18 {
+		iface MIXER
+		name 'ADC Voice Cutoff'
+		value '2.5Hz'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '2.5Hz'
+			item.1 '25Hz'
+			item.2 '50Hz'
+			item.3 '100Hz'
+			item.4 '150Hz'
+			item.5 '200Hz'
+			item.6 '300Hz'
+			item.7 '400Hz'
+		}
+	}
+	control.19 {
+		iface MIXER
+		name 'DAC HPF Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.20 {
+		iface MIXER
+		name 'DAC HPF Cutoff'
+		value Fs/24000
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Fs/24000
+			item.1 Fs/12000
+			item.2 Fs/6000
+			item.3 Fs/3000
+		}
+	}
+	control.21 {
+		iface MIXER
+		name 'DAC Voice Mode Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.22 {
+		iface MIXER
+		name 'DAC Voice Cutoff'
+		value '2.5Hz'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '2.5Hz'
+			item.1 '25Hz'
+			item.2 '50Hz'
+			item.3 '100Hz'
+			item.4 '150Hz'
+			item.5 '200Hz'
+			item.6 '300Hz'
+			item.7 '400Hz'
+		}
+	}
+	control.23 {
+		iface MIXER
+		name 'Mic 1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.24 {
+		iface MIXER
+		name 'Mic 2 Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.25 {
+		iface MIXER
+		name 'Aux Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.26 {
+		iface MIXER
+		name 'Mixin PGA Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.27 {
+		iface MIXER
+		name 'ADC Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.28 {
+		iface MIXER
+		name 'Headphone Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.29 {
+		iface MIXER
+		name 'Lineout Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.30 {
+		iface MIXER
+		name 'DAC Soft Mute Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.31 {
+		iface MIXER
+		name 'DAC Soft Mute Rate'
+		value '1'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '1'
+			item.1 '2'
+			item.2 '4'
+			item.3 '8'
+			item.4 '16'
+			item.5 '32'
+			item.6 '64'
+		}
+	}
+	control.32 {
+		iface MIXER
+		name 'Aux ZC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.33 {
+		iface MIXER
+		name 'Mixin PGA ZC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.34 {
+		iface MIXER
+		name 'Headphone ZC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.35 {
+		iface MIXER
+		name 'Aux Gain Ramping Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.36 {
+		iface MIXER
+		name 'Mixin Gain Ramping Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.37 {
+		iface MIXER
+		name 'ADC Gain Ramping Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.38 {
+		iface MIXER
+		name 'DAC Gain Ramping Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.39 {
+		iface MIXER
+		name 'Headphone Gain Ramping Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.40 {
+		iface MIXER
+		name 'Lineout Gain Ramping Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.41 {
+		iface MIXER
+		name 'Gain Ramping Rate'
+		value 'nominal rate * 8'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'nominal rate * 8'
+			item.1 'nominal rate * 16'
+			item.2 'nominal rate / 16'
+			item.3 'nominal rate / 32'
+		}
+	}
+	control.42 {
+		iface MIXER
+		name 'DAC NG Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.43 {
+		iface MIXER
+		name 'DAC NG Setup Time'
+		value '256 samples'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '256 samples'
+			item.1 '512 samples'
+			item.2 '1024 samples'
+			item.3 '2048 samples'
+		}
+	}
+	control.44 {
+		iface MIXER
+		name 'DAC NG Rampup Rate'
+		value '0.02 ms/dB'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '0.02 ms/dB'
+			item.1 '0.16 ms/dB'
+		}
+	}
+	control.45 {
+		iface MIXER
+		name 'DAC NG Rampdown Rate'
+		value '0.64 ms/dB'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '0.64 ms/dB'
+			item.1 '20.48 ms/dB'
+		}
+	}
+	control.46 {
+		iface MIXER
+		name 'DAC NG OFF Threshold'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.47 {
+		iface MIXER
+		name 'DAC NG ON Threshold'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.48 {
+		iface MIXER
+		name 'DAC Mono Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.49 {
+		iface MIXER
+		name 'DAC Invert Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.50 {
+		iface MIXER
+		name 'DMIC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.51 {
+		iface MIXER
+		name 'ALC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.52 {
+		iface MIXER
+		name 'ALC Attack Rate'
+		value '44/fs'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '44/fs'
+			item.1 '88/fs'
+			item.2 '176/fs'
+			item.3 '352/fs'
+			item.4 '704/fs'
+			item.5 '1408/fs'
+			item.6 '2816/fs'
+			item.7 '5632/fs'
+			item.8 '11264/fs'
+			item.9 '22528/fs'
+			item.10 '45056/fs'
+			item.11 '90112/fs'
+			item.12 '180224/fs'
+		}
+	}
+	control.53 {
+		iface MIXER
+		name 'ALC Release Rate'
+		value '176/fs'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '176/fs'
+			item.1 '352/fs'
+			item.2 '704/fs'
+			item.3 '1408/fs'
+			item.4 '2816/fs'
+			item.5 '5632/fs'
+			item.6 '11264/fs'
+			item.7 '22528/fs'
+			item.8 '45056/fs'
+			item.9 '90112/fs'
+			item.10 '180224/fs'
+		}
+	}
+	control.54 {
+		iface MIXER
+		name 'ALC Hold Time'
+		value '62/fs'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '62/fs'
+			item.1 '124/fs'
+			item.2 '248/fs'
+			item.3 '496/fs'
+			item.4 '992/fs'
+			item.5 '1984/fs'
+			item.6 '3968/fs'
+			item.7 '7936/fs'
+			item.8 '15872/fs'
+			item.9 '31744/fs'
+			item.10 '63488/fs'
+			item.11 '126976/fs'
+			item.12 '253952/fs'
+			item.13 '507904/fs'
+			item.14 '1015808/fs'
+			item.15 '2031616/fs'
+		}
+	}
+	control.55 {
+		iface MIXER
+		name 'ALC Integ Attack Rate'
+		value '1/4'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '1/4'
+			item.1 '1/16'
+			item.2 '1/256'
+			item.3 '1/65536'
+		}
+	}
+	control.56 {
+		iface MIXER
+		name 'ALC Integ Release Rate'
+		value '1/4'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '1/4'
+			item.1 '1/16'
+			item.2 '1/256'
+			item.3 '1/65536'
+		}
+	}
+	control.57 {
+		iface MIXER
+		name 'ALC Noise Threshold Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+			dbmin -9450
+			dbmax 0
+			dbvalue.0 -9450
+		}
+	}
+	control.58 {
+		iface MIXER
+		name 'ALC Min Threshold Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+			dbmin -9450
+			dbmax 0
+			dbvalue.0 -9450
+		}
+	}
+	control.59 {
+		iface MIXER
+		name 'ALC Max Threshold Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+			dbmin -9450
+			dbmax 0
+			dbvalue.0 -9450
+		}
+	}
+	control.60 {
+		iface MIXER
+		name 'ALC Max Attenuation Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin 0
+			dbmax 9000
+			dbvalue.0 0
+		}
+	}
+	control.61 {
+		iface MIXER
+		name 'ALC Max Gain Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin 0
+			dbmax 9000
+			dbvalue.0 0
+		}
+	}
+	control.62 {
+		iface MIXER
+		name 'ALC Min Analog Gain Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -9999999
+			dbmax 3600
+			dbvalue.0 -9999999
+		}
+	}
+	control.63 {
+		iface MIXER
+		name 'ALC Max Analog Gain Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -9999999
+			dbmax 3600
+			dbvalue.0 -9999999
+		}
+	}
+	control.64 {
+		iface MIXER
+		name 'ALC Anticlip Mode Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.65 {
+		iface MIXER
+		name 'ALC Anticlip Level'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 127'
+		}
+	}
+	control.66 {
+		iface MIXER
+		name 'HP Jack Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.67 {
+		iface MIXER
+		name 'MIC Jack Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.68 {
+		iface MIXER
+		name 'Onboard MIC Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.69 {
+		iface MIXER
+		name 'AUX Jack Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.70 {
+		iface MIXER
+		name 'Mic 1 Amp Source MUX'
+		value Differential
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Differential
+			item.1 MIC_P
+			item.2 MIC_N
+		}
+	}
+	control.71 {
+		iface MIXER
+		name 'Mic 2 Amp Source MUX'
+		value Differential
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Differential
+			item.1 MIC_P
+			item.2 MIC_N
+		}
+	}
+	control.72 {
+		iface MIXER
+		name 'Mixin Left Aux Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.73 {
+		iface MIXER
+		name 'Mixin Left Mic 1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.74 {
+		iface MIXER
+		name 'Mixin Left Mic 2 Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.75 {
+		iface MIXER
+		name 'Mixin Left Mixin Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.76 {
+		iface MIXER
+		name 'Mixin Right Aux Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.77 {
+		iface MIXER
+		name 'Mixin Right Mic 2 Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.78 {
+		iface MIXER
+		name 'Mixin Right Mic 1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.79 {
+		iface MIXER
+		name 'Mixin Right Mixin Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.80 {
+		iface MIXER
+		name 'DAI Left Source MUX'
+		value 'ADC Left'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'ADC Left'
+			item.1 'ADC Right'
+			item.2 'DAI Input Left'
+			item.3 'DAI Input Right'
+		}
+	}
+	control.81 {
+		iface MIXER
+		name 'DAI Right Source MUX'
+		value 'ADC Right'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'ADC Left'
+			item.1 'ADC Right'
+			item.2 'DAI Input Left'
+			item.3 'DAI Input Right'
+		}
+	}
+	control.82 {
+		iface MIXER
+		name 'DAC Left Source MUX'
+		value 'DAI Input Left'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'ADC Output Left'
+			item.1 'ADC Output Right'
+			item.2 'DAI Input Left'
+			item.3 'DAI Input Right'
+		}
+	}
+	control.83 {
+		iface MIXER
+		name 'DAC Right Source MUX'
+		value 'DAI Input Right'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'ADC Output Left'
+			item.1 'ADC Output Right'
+			item.2 'DAI Input Left'
+			item.3 'DAI Input Right'
+		}
+	}
+	control.84 {
+		iface MIXER
+		name 'Mixout Left Aux Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.85 {
+		iface MIXER
+		name 'Mixout Left Mixin Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.86 {
+		iface MIXER
+		name 'Mixout Left Mixin Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.87 {
+		iface MIXER
+		name 'Mixout Left DAC Left Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.88 {
+		iface MIXER
+		name 'Mixout Left Aux Left Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.89 {
+		iface MIXER
+		name 'Mixout Left Mixin Left Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.90 {
+		iface MIXER
+		name 'Mixout Left Mixin Right Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.91 {
+		iface MIXER
+		name 'Mixout Right Aux Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.92 {
+		iface MIXER
+		name 'Mixout Right Mixin Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.93 {
+		iface MIXER
+		name 'Mixout Right Mixin Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.94 {
+		iface MIXER
+		name 'Mixout Right DAC Right Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.95 {
+		iface MIXER
+		name 'Mixout Right Aux Right Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.96 {
+		iface MIXER
+		name 'Mixout Right Mixin Right Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.97 {
+		iface MIXER
+		name 'Mixout Right Mixin Left Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+}

--- a/RPi_Zero_Playback_Only.state
+++ b/RPi_Zero_Playback_Only.state
@@ -1,0 +1,1194 @@
+state.Zero {
+	control.1 {
+		iface MIXER
+		name 'Mic 1 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -600
+			dbmax 3600
+			dbvalue.0 -600
+		}
+	}
+	control.2 {
+		iface MIXER
+		name 'Mic 2 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -600
+			dbmax 3600
+			dbvalue.0 -600
+		}
+	}
+	control.3 {
+		iface MIXER
+		name 'Aux Volume'
+		value.0 19
+		value.1 19
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 63'
+			dbmin -5400
+			dbmax 1500
+			dbvalue.0 -5100
+			dbvalue.1 -5100
+		}
+	}
+	control.4 {
+		iface MIXER
+		name 'Mixin PGA Volume'
+		value.0 7
+		value.1 7
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 15'
+			dbmin -450
+			dbmax 1800
+			dbvalue.0 600
+			dbvalue.1 600
+		}
+	}
+	control.5 {
+		iface MIXER
+		name 'ADC Volume'
+		value.0 112
+		value.1 112
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 127'
+			dbmin -9999999
+			dbmax 1125
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.6 {
+		iface MIXER
+		name 'DAC Volume'
+		value.0 112
+		value.1 112
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 127'
+			dbmin -9999999
+			dbmax 1125
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.7 {
+		iface MIXER
+		name 'Headphone Volume'
+		value.0 49
+		value.1 49
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 63'
+			dbmin -5700
+			dbmax 600
+			dbvalue.0 -800
+			dbvalue.1 -800
+		}
+	}
+	control.8 {
+		iface MIXER
+		name 'Lineout Volume'
+		value 51
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+			dbmin -4800
+			dbmax 1500
+			dbvalue.0 300
+		}
+	}
+	control.9 {
+		iface MIXER
+		name 'DAC EQ Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.10 {
+		iface MIXER
+		name 'DAC EQ1 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.11 {
+		iface MIXER
+		name 'DAC EQ2 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.12 {
+		iface MIXER
+		name 'DAC EQ3 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.13 {
+		iface MIXER
+		name 'DAC EQ4 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.14 {
+		iface MIXER
+		name 'DAC EQ5 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.15 {
+		iface MIXER
+		name 'ADC HPF Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.16 {
+		iface MIXER
+		name 'ADC HPF Cutoff'
+		value Fs/24000
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Fs/24000
+			item.1 Fs/12000
+			item.2 Fs/6000
+			item.3 Fs/3000
+		}
+	}
+	control.17 {
+		iface MIXER
+		name 'ADC Voice Mode Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.18 {
+		iface MIXER
+		name 'ADC Voice Cutoff'
+		value '2.5Hz'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '2.5Hz'
+			item.1 '25Hz'
+			item.2 '50Hz'
+			item.3 '100Hz'
+			item.4 '150Hz'
+			item.5 '200Hz'
+			item.6 '300Hz'
+			item.7 '400Hz'
+		}
+	}
+	control.19 {
+		iface MIXER
+		name 'DAC HPF Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.20 {
+		iface MIXER
+		name 'DAC HPF Cutoff'
+		value Fs/24000
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Fs/24000
+			item.1 Fs/12000
+			item.2 Fs/6000
+			item.3 Fs/3000
+		}
+	}
+	control.21 {
+		iface MIXER
+		name 'DAC Voice Mode Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.22 {
+		iface MIXER
+		name 'DAC Voice Cutoff'
+		value '2.5Hz'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '2.5Hz'
+			item.1 '25Hz'
+			item.2 '50Hz'
+			item.3 '100Hz'
+			item.4 '150Hz'
+			item.5 '200Hz'
+			item.6 '300Hz'
+			item.7 '400Hz'
+		}
+	}
+	control.23 {
+		iface MIXER
+		name 'Mic 1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.24 {
+		iface MIXER
+		name 'Mic 2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.25 {
+		iface MIXER
+		name 'Aux Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.26 {
+		iface MIXER
+		name 'Mixin PGA Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.27 {
+		iface MIXER
+		name 'ADC Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.28 {
+		iface MIXER
+		name 'Headphone Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.29 {
+		iface MIXER
+		name 'Lineout Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.30 {
+		iface MIXER
+		name 'DAC Soft Mute Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.31 {
+		iface MIXER
+		name 'DAC Soft Mute Rate'
+		value '1'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '1'
+			item.1 '2'
+			item.2 '4'
+			item.3 '8'
+			item.4 '16'
+			item.5 '32'
+			item.6 '64'
+		}
+	}
+	control.32 {
+		iface MIXER
+		name 'Aux ZC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.33 {
+		iface MIXER
+		name 'Mixin PGA ZC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.34 {
+		iface MIXER
+		name 'Headphone ZC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.35 {
+		iface MIXER
+		name 'Aux Gain Ramping Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.36 {
+		iface MIXER
+		name 'Mixin Gain Ramping Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.37 {
+		iface MIXER
+		name 'ADC Gain Ramping Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.38 {
+		iface MIXER
+		name 'DAC Gain Ramping Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.39 {
+		iface MIXER
+		name 'Headphone Gain Ramping Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.40 {
+		iface MIXER
+		name 'Lineout Gain Ramping Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.41 {
+		iface MIXER
+		name 'Gain Ramping Rate'
+		value 'nominal rate * 8'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'nominal rate * 8'
+			item.1 'nominal rate * 16'
+			item.2 'nominal rate / 16'
+			item.3 'nominal rate / 32'
+		}
+	}
+	control.42 {
+		iface MIXER
+		name 'DAC NG Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.43 {
+		iface MIXER
+		name 'DAC NG Setup Time'
+		value '256 samples'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '256 samples'
+			item.1 '512 samples'
+			item.2 '1024 samples'
+			item.3 '2048 samples'
+		}
+	}
+	control.44 {
+		iface MIXER
+		name 'DAC NG Rampup Rate'
+		value '0.02 ms/dB'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '0.02 ms/dB'
+			item.1 '0.16 ms/dB'
+		}
+	}
+	control.45 {
+		iface MIXER
+		name 'DAC NG Rampdown Rate'
+		value '0.64 ms/dB'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '0.64 ms/dB'
+			item.1 '20.48 ms/dB'
+		}
+	}
+	control.46 {
+		iface MIXER
+		name 'DAC NG OFF Threshold'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.47 {
+		iface MIXER
+		name 'DAC NG ON Threshold'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.48 {
+		iface MIXER
+		name 'DAC Mono Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.49 {
+		iface MIXER
+		name 'DAC Invert Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.50 {
+		iface MIXER
+		name 'DMIC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.51 {
+		iface MIXER
+		name 'ALC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.52 {
+		iface MIXER
+		name 'ALC Attack Rate'
+		value '44/fs'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '44/fs'
+			item.1 '88/fs'
+			item.2 '176/fs'
+			item.3 '352/fs'
+			item.4 '704/fs'
+			item.5 '1408/fs'
+			item.6 '2816/fs'
+			item.7 '5632/fs'
+			item.8 '11264/fs'
+			item.9 '22528/fs'
+			item.10 '45056/fs'
+			item.11 '90112/fs'
+			item.12 '180224/fs'
+		}
+	}
+	control.53 {
+		iface MIXER
+		name 'ALC Release Rate'
+		value '176/fs'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '176/fs'
+			item.1 '352/fs'
+			item.2 '704/fs'
+			item.3 '1408/fs'
+			item.4 '2816/fs'
+			item.5 '5632/fs'
+			item.6 '11264/fs'
+			item.7 '22528/fs'
+			item.8 '45056/fs'
+			item.9 '90112/fs'
+			item.10 '180224/fs'
+		}
+	}
+	control.54 {
+		iface MIXER
+		name 'ALC Hold Time'
+		value '62/fs'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '62/fs'
+			item.1 '124/fs'
+			item.2 '248/fs'
+			item.3 '496/fs'
+			item.4 '992/fs'
+			item.5 '1984/fs'
+			item.6 '3968/fs'
+			item.7 '7936/fs'
+			item.8 '15872/fs'
+			item.9 '31744/fs'
+			item.10 '63488/fs'
+			item.11 '126976/fs'
+			item.12 '253952/fs'
+			item.13 '507904/fs'
+			item.14 '1015808/fs'
+			item.15 '2031616/fs'
+		}
+	}
+	control.55 {
+		iface MIXER
+		name 'ALC Integ Attack Rate'
+		value '1/4'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '1/4'
+			item.1 '1/16'
+			item.2 '1/256'
+			item.3 '1/65536'
+		}
+	}
+	control.56 {
+		iface MIXER
+		name 'ALC Integ Release Rate'
+		value '1/4'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '1/4'
+			item.1 '1/16'
+			item.2 '1/256'
+			item.3 '1/65536'
+		}
+	}
+	control.57 {
+		iface MIXER
+		name 'ALC Noise Threshold Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+			dbmin -9450
+			dbmax 0
+			dbvalue.0 -9450
+		}
+	}
+	control.58 {
+		iface MIXER
+		name 'ALC Min Threshold Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+			dbmin -9450
+			dbmax 0
+			dbvalue.0 -9450
+		}
+	}
+	control.59 {
+		iface MIXER
+		name 'ALC Max Threshold Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+			dbmin -9450
+			dbmax 0
+			dbvalue.0 -9450
+		}
+	}
+	control.60 {
+		iface MIXER
+		name 'ALC Max Attenuation Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin 0
+			dbmax 9000
+			dbvalue.0 0
+		}
+	}
+	control.61 {
+		iface MIXER
+		name 'ALC Max Gain Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin 0
+			dbmax 9000
+			dbvalue.0 0
+		}
+	}
+	control.62 {
+		iface MIXER
+		name 'ALC Min Analog Gain Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -9999999
+			dbmax 3600
+			dbvalue.0 -9999999
+		}
+	}
+	control.63 {
+		iface MIXER
+		name 'ALC Max Analog Gain Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -9999999
+			dbmax 3600
+			dbvalue.0 -9999999
+		}
+	}
+	control.64 {
+		iface MIXER
+		name 'ALC Anticlip Mode Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.65 {
+		iface MIXER
+		name 'ALC Anticlip Level'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 127'
+		}
+	}
+	control.66 {
+		iface MIXER
+		name 'HP Jack Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.67 {
+		iface MIXER
+		name 'MIC Jack Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.68 {
+		iface MIXER
+		name 'Onboard MIC Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.69 {
+		iface MIXER
+		name 'AUX Jack Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.70 {
+		iface MIXER
+		name 'Mic 1 Amp Source MUX'
+		value Differential
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Differential
+			item.1 MIC_P
+			item.2 MIC_N
+		}
+	}
+	control.71 {
+		iface MIXER
+		name 'Mic 2 Amp Source MUX'
+		value Differential
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Differential
+			item.1 MIC_P
+			item.2 MIC_N
+		}
+	}
+	control.72 {
+		iface MIXER
+		name 'Mixin Left Aux Left Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.73 {
+		iface MIXER
+		name 'Mixin Left Mic 1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.74 {
+		iface MIXER
+		name 'Mixin Left Mic 2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.75 {
+		iface MIXER
+		name 'Mixin Left Mixin Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.76 {
+		iface MIXER
+		name 'Mixin Right Aux Right Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.77 {
+		iface MIXER
+		name 'Mixin Right Mic 2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.78 {
+		iface MIXER
+		name 'Mixin Right Mic 1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.79 {
+		iface MIXER
+		name 'Mixin Right Mixin Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.80 {
+		iface MIXER
+		name 'DAI Left Source MUX'
+		value 'ADC Left'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'ADC Left'
+			item.1 'ADC Right'
+			item.2 'DAI Input Left'
+			item.3 'DAI Input Right'
+		}
+	}
+	control.81 {
+		iface MIXER
+		name 'DAI Right Source MUX'
+		value 'ADC Right'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'ADC Left'
+			item.1 'ADC Right'
+			item.2 'DAI Input Left'
+			item.3 'DAI Input Right'
+		}
+	}
+	control.82 {
+		iface MIXER
+		name 'DAC Left Source MUX'
+		value 'DAI Input Left'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'ADC Output Left'
+			item.1 'ADC Output Right'
+			item.2 'DAI Input Left'
+			item.3 'DAI Input Right'
+		}
+	}
+	control.83 {
+		iface MIXER
+		name 'DAC Right Source MUX'
+		value 'DAI Input Right'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'ADC Output Left'
+			item.1 'ADC Output Right'
+			item.2 'DAI Input Left'
+			item.3 'DAI Input Right'
+		}
+	}
+	control.84 {
+		iface MIXER
+		name 'Mixout Left Aux Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.85 {
+		iface MIXER
+		name 'Mixout Left Mixin Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.86 {
+		iface MIXER
+		name 'Mixout Left Mixin Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.87 {
+		iface MIXER
+		name 'Mixout Left DAC Left Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.88 {
+		iface MIXER
+		name 'Mixout Left Aux Left Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.89 {
+		iface MIXER
+		name 'Mixout Left Mixin Left Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.90 {
+		iface MIXER
+		name 'Mixout Left Mixin Right Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.91 {
+		iface MIXER
+		name 'Mixout Right Aux Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.92 {
+		iface MIXER
+		name 'Mixout Right Mixin Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.93 {
+		iface MIXER
+		name 'Mixout Right Mixin Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.94 {
+		iface MIXER
+		name 'Mixout Right DAC Right Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.95 {
+		iface MIXER
+		name 'Mixout Right Aux Right Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.96 {
+		iface MIXER
+		name 'Mixout Right Mixin Right Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.97 {
+		iface MIXER
+		name 'Mixout Right Mixin Left Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+}

--- a/RPi_Zero_StereoMIC_record_and_HP_playback.state
+++ b/RPi_Zero_StereoMIC_record_and_HP_playback.state
@@ -1,0 +1,1194 @@
+state.Zero {
+	control.1 {
+		iface MIXER
+		name 'Mic 1 Volume'
+		value 5
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -600
+			dbmax 3600
+			dbvalue.0 2400
+		}
+	}
+	control.2 {
+		iface MIXER
+		name 'Mic 2 Volume'
+		value 5
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -600
+			dbmax 3600
+			dbvalue.0 2400
+		}
+	}
+	control.3 {
+		iface MIXER
+		name 'Aux Volume'
+		value.0 0
+		value.1 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 63'
+			dbmin -5400
+			dbmax 1500
+			dbvalue.0 -5400
+			dbvalue.1 -5400
+		}
+	}
+	control.4 {
+		iface MIXER
+		name 'Mixin PGA Volume'
+		value.0 7
+		value.1 5
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 15'
+			dbmin -450
+			dbmax 1800
+			dbvalue.0 600
+			dbvalue.1 300
+		}
+	}
+	control.5 {
+		iface MIXER
+		name 'ADC Volume'
+		value.0 114
+		value.1 114
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 127'
+			dbmin -9999999
+			dbmax 1125
+			dbvalue.0 150
+			dbvalue.1 150
+		}
+	}
+	control.6 {
+		iface MIXER
+		name 'DAC Volume'
+		value.0 112
+		value.1 112
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 127'
+			dbmin -9999999
+			dbmax 1125
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.7 {
+		iface MIXER
+		name 'Headphone Volume'
+		value.0 49
+		value.1 49
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 63'
+			dbmin -5700
+			dbmax 600
+			dbvalue.0 -800
+			dbvalue.1 -800
+		}
+	}
+	control.8 {
+		iface MIXER
+		name 'Lineout Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+			dbmin -4800
+			dbmax 1500
+			dbvalue.0 -4800
+		}
+	}
+	control.9 {
+		iface MIXER
+		name 'DAC EQ Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.10 {
+		iface MIXER
+		name 'DAC EQ1 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.11 {
+		iface MIXER
+		name 'DAC EQ2 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.12 {
+		iface MIXER
+		name 'DAC EQ3 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.13 {
+		iface MIXER
+		name 'DAC EQ4 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.14 {
+		iface MIXER
+		name 'DAC EQ5 Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin -1050
+			dbmax 1200
+			dbvalue.0 -1050
+		}
+	}
+	control.15 {
+		iface MIXER
+		name 'ADC HPF Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.16 {
+		iface MIXER
+		name 'ADC HPF Cutoff'
+		value Fs/24000
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Fs/24000
+			item.1 Fs/12000
+			item.2 Fs/6000
+			item.3 Fs/3000
+		}
+	}
+	control.17 {
+		iface MIXER
+		name 'ADC Voice Mode Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.18 {
+		iface MIXER
+		name 'ADC Voice Cutoff'
+		value '2.5Hz'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '2.5Hz'
+			item.1 '25Hz'
+			item.2 '50Hz'
+			item.3 '100Hz'
+			item.4 '150Hz'
+			item.5 '200Hz'
+			item.6 '300Hz'
+			item.7 '400Hz'
+		}
+	}
+	control.19 {
+		iface MIXER
+		name 'DAC HPF Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.20 {
+		iface MIXER
+		name 'DAC HPF Cutoff'
+		value Fs/24000
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Fs/24000
+			item.1 Fs/12000
+			item.2 Fs/6000
+			item.3 Fs/3000
+		}
+	}
+	control.21 {
+		iface MIXER
+		name 'DAC Voice Mode Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.22 {
+		iface MIXER
+		name 'DAC Voice Cutoff'
+		value '2.5Hz'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '2.5Hz'
+			item.1 '25Hz'
+			item.2 '50Hz'
+			item.3 '100Hz'
+			item.4 '150Hz'
+			item.5 '200Hz'
+			item.6 '300Hz'
+			item.7 '400Hz'
+		}
+	}
+	control.23 {
+		iface MIXER
+		name 'Mic 1 Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.24 {
+		iface MIXER
+		name 'Mic 2 Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.25 {
+		iface MIXER
+		name 'Aux Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.26 {
+		iface MIXER
+		name 'Mixin PGA Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.27 {
+		iface MIXER
+		name 'ADC Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.28 {
+		iface MIXER
+		name 'Headphone Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.29 {
+		iface MIXER
+		name 'Lineout Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.30 {
+		iface MIXER
+		name 'DAC Soft Mute Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.31 {
+		iface MIXER
+		name 'DAC Soft Mute Rate'
+		value '1'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '1'
+			item.1 '2'
+			item.2 '4'
+			item.3 '8'
+			item.4 '16'
+			item.5 '32'
+			item.6 '64'
+		}
+	}
+	control.32 {
+		iface MIXER
+		name 'Aux ZC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.33 {
+		iface MIXER
+		name 'Mixin PGA ZC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.34 {
+		iface MIXER
+		name 'Headphone ZC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.35 {
+		iface MIXER
+		name 'Aux Gain Ramping Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.36 {
+		iface MIXER
+		name 'Mixin Gain Ramping Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.37 {
+		iface MIXER
+		name 'ADC Gain Ramping Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.38 {
+		iface MIXER
+		name 'DAC Gain Ramping Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.39 {
+		iface MIXER
+		name 'Headphone Gain Ramping Switch'
+		value.0 true
+		value.1 true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.40 {
+		iface MIXER
+		name 'Lineout Gain Ramping Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.41 {
+		iface MIXER
+		name 'Gain Ramping Rate'
+		value 'nominal rate * 8'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'nominal rate * 8'
+			item.1 'nominal rate * 16'
+			item.2 'nominal rate / 16'
+			item.3 'nominal rate / 32'
+		}
+	}
+	control.42 {
+		iface MIXER
+		name 'DAC NG Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.43 {
+		iface MIXER
+		name 'DAC NG Setup Time'
+		value '256 samples'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '256 samples'
+			item.1 '512 samples'
+			item.2 '1024 samples'
+			item.3 '2048 samples'
+		}
+	}
+	control.44 {
+		iface MIXER
+		name 'DAC NG Rampup Rate'
+		value '0.02 ms/dB'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '0.02 ms/dB'
+			item.1 '0.16 ms/dB'
+		}
+	}
+	control.45 {
+		iface MIXER
+		name 'DAC NG Rampdown Rate'
+		value '0.64 ms/dB'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '0.64 ms/dB'
+			item.1 '20.48 ms/dB'
+		}
+	}
+	control.46 {
+		iface MIXER
+		name 'DAC NG OFF Threshold'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.47 {
+		iface MIXER
+		name 'DAC NG ON Threshold'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+		}
+	}
+	control.48 {
+		iface MIXER
+		name 'DAC Mono Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.49 {
+		iface MIXER
+		name 'DAC Invert Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.50 {
+		iface MIXER
+		name 'DMIC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.51 {
+		iface MIXER
+		name 'ALC Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.52 {
+		iface MIXER
+		name 'ALC Attack Rate'
+		value '44/fs'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '44/fs'
+			item.1 '88/fs'
+			item.2 '176/fs'
+			item.3 '352/fs'
+			item.4 '704/fs'
+			item.5 '1408/fs'
+			item.6 '2816/fs'
+			item.7 '5632/fs'
+			item.8 '11264/fs'
+			item.9 '22528/fs'
+			item.10 '45056/fs'
+			item.11 '90112/fs'
+			item.12 '180224/fs'
+		}
+	}
+	control.53 {
+		iface MIXER
+		name 'ALC Release Rate'
+		value '176/fs'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '176/fs'
+			item.1 '352/fs'
+			item.2 '704/fs'
+			item.3 '1408/fs'
+			item.4 '2816/fs'
+			item.5 '5632/fs'
+			item.6 '11264/fs'
+			item.7 '22528/fs'
+			item.8 '45056/fs'
+			item.9 '90112/fs'
+			item.10 '180224/fs'
+		}
+	}
+	control.54 {
+		iface MIXER
+		name 'ALC Hold Time'
+		value '62/fs'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '62/fs'
+			item.1 '124/fs'
+			item.2 '248/fs'
+			item.3 '496/fs'
+			item.4 '992/fs'
+			item.5 '1984/fs'
+			item.6 '3968/fs'
+			item.7 '7936/fs'
+			item.8 '15872/fs'
+			item.9 '31744/fs'
+			item.10 '63488/fs'
+			item.11 '126976/fs'
+			item.12 '253952/fs'
+			item.13 '507904/fs'
+			item.14 '1015808/fs'
+			item.15 '2031616/fs'
+		}
+	}
+	control.55 {
+		iface MIXER
+		name 'ALC Integ Attack Rate'
+		value '1/4'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '1/4'
+			item.1 '1/16'
+			item.2 '1/256'
+			item.3 '1/65536'
+		}
+	}
+	control.56 {
+		iface MIXER
+		name 'ALC Integ Release Rate'
+		value '1/4'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '1/4'
+			item.1 '1/16'
+			item.2 '1/256'
+			item.3 '1/65536'
+		}
+	}
+	control.57 {
+		iface MIXER
+		name 'ALC Noise Threshold Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+			dbmin -9450
+			dbmax 0
+			dbvalue.0 -9450
+		}
+	}
+	control.58 {
+		iface MIXER
+		name 'ALC Min Threshold Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+			dbmin -9450
+			dbmax 0
+			dbvalue.0 -9450
+		}
+	}
+	control.59 {
+		iface MIXER
+		name 'ALC Max Threshold Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 63'
+			dbmin -9450
+			dbmax 0
+			dbvalue.0 -9450
+		}
+	}
+	control.60 {
+		iface MIXER
+		name 'ALC Max Attenuation Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin 0
+			dbmax 9000
+			dbvalue.0 0
+		}
+	}
+	control.61 {
+		iface MIXER
+		name 'ALC Max Gain Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 15'
+			dbmin 0
+			dbmax 9000
+			dbvalue.0 0
+		}
+	}
+	control.62 {
+		iface MIXER
+		name 'ALC Min Analog Gain Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -9999999
+			dbmax 3600
+			dbvalue.0 -9999999
+		}
+	}
+	control.63 {
+		iface MIXER
+		name 'ALC Max Analog Gain Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 7'
+			dbmin -9999999
+			dbmax 3600
+			dbvalue.0 -9999999
+		}
+	}
+	control.64 {
+		iface MIXER
+		name 'ALC Anticlip Mode Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.65 {
+		iface MIXER
+		name 'ALC Anticlip Level'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 127'
+		}
+	}
+	control.66 {
+		iface MIXER
+		name 'HP Jack Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.67 {
+		iface MIXER
+		name 'MIC Jack Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.68 {
+		iface MIXER
+		name 'Onboard MIC Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.69 {
+		iface MIXER
+		name 'AUX Jack Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.70 {
+		iface MIXER
+		name 'Mic 1 Amp Source MUX'
+		value Differential
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Differential
+			item.1 MIC_P
+			item.2 MIC_N
+		}
+	}
+	control.71 {
+		iface MIXER
+		name 'Mic 2 Amp Source MUX'
+		value Differential
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Differential
+			item.1 MIC_P
+			item.2 MIC_N
+		}
+	}
+	control.72 {
+		iface MIXER
+		name 'Mixin Left Aux Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.73 {
+		iface MIXER
+		name 'Mixin Left Mic 1 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.74 {
+		iface MIXER
+		name 'Mixin Left Mic 2 Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.75 {
+		iface MIXER
+		name 'Mixin Left Mixin Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.76 {
+		iface MIXER
+		name 'Mixin Right Aux Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.77 {
+		iface MIXER
+		name 'Mixin Right Mic 2 Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.78 {
+		iface MIXER
+		name 'Mixin Right Mic 1 Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.79 {
+		iface MIXER
+		name 'Mixin Right Mixin Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.80 {
+		iface MIXER
+		name 'DAI Left Source MUX'
+		value 'ADC Left'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'ADC Left'
+			item.1 'ADC Right'
+			item.2 'DAI Input Left'
+			item.3 'DAI Input Right'
+		}
+	}
+	control.81 {
+		iface MIXER
+		name 'DAI Right Source MUX'
+		value 'ADC Right'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'ADC Left'
+			item.1 'ADC Right'
+			item.2 'DAI Input Left'
+			item.3 'DAI Input Right'
+		}
+	}
+	control.82 {
+		iface MIXER
+		name 'DAC Left Source MUX'
+		value 'DAI Input Left'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'ADC Output Left'
+			item.1 'ADC Output Right'
+			item.2 'DAI Input Left'
+			item.3 'DAI Input Right'
+		}
+	}
+	control.83 {
+		iface MIXER
+		name 'DAC Right Source MUX'
+		value 'DAI Input Right'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'ADC Output Left'
+			item.1 'ADC Output Right'
+			item.2 'DAI Input Left'
+			item.3 'DAI Input Right'
+		}
+	}
+	control.84 {
+		iface MIXER
+		name 'Mixout Left Aux Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.85 {
+		iface MIXER
+		name 'Mixout Left Mixin Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.86 {
+		iface MIXER
+		name 'Mixout Left Mixin Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.87 {
+		iface MIXER
+		name 'Mixout Left DAC Left Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.88 {
+		iface MIXER
+		name 'Mixout Left Aux Left Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.89 {
+		iface MIXER
+		name 'Mixout Left Mixin Left Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.90 {
+		iface MIXER
+		name 'Mixout Left Mixin Right Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.91 {
+		iface MIXER
+		name 'Mixout Right Aux Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.92 {
+		iface MIXER
+		name 'Mixout Right Mixin Right Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.93 {
+		iface MIXER
+		name 'Mixout Right Mixin Left Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.94 {
+		iface MIXER
+		name 'Mixout Right DAC Right Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.95 {
+		iface MIXER
+		name 'Mixout Right Aux Right Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.96 {
+		iface MIXER
+		name 'Mixout Right Mixin Right Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.97 {
+		iface MIXER
+		name 'Mixout Right Mixin Left Invert Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+}


### PR DESCRIPTION
Seems like we need to `s/IQaudIOCODEC/Zero/` for the newer RPi Codec Zeros. See raspberrypi/documentation#2961 .
